### PR TITLE
feat: declare camera/media permissions in library manifest

### DIFF
--- a/camera/src/main/AndroidManifest.xml
+++ b/camera/src/main/AndroidManifest.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!--
+        Permissions required by the camera library.
+        Declared here so consuming apps don't need to add them manually.
+        READ_MEDIA_IMAGES + READ_MEDIA_VIDEO + READ_MEDIA_VISUAL_USER_SELECTED must all be
+        declared without maxSdkVersion so Android 14+ shows the "Allow all / Select photos /
+        Don't allow" system dialog when the three are requested together at runtime.
+    -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_IMAGES"
+        android:maxSdkVersion="33" />
+    <uses-permission
+        android:name="android.permission.READ_MEDIA_VIDEO"
+        android:maxSdkVersion="33" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
+
 </manifest>

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,4 @@ android.nonTransitiveRClass=true
 # Publishing version (used by camera/build.gradle.kts).
 # Bump this for each release. Tag the commit with the same value.
 # ============================================================
-SDK_VERSION=1.0.13
+SDK_VERSION=1.0.14


### PR DESCRIPTION
Move CAMERA, RECORD_AUDIO, READ_MEDIA_IMAGES, READ_MEDIA_VIDEO and READ_MEDIA_VISUAL_USER_SELECTED into the library's own AndroidManifest so consuming apps get them via AAR merge without manual declaration.

READ_MEDIA_IMAGES and READ_MEDIA_VIDEO are capped at maxSdkVersion=33 (API 34+ uses READ_MEDIA_VISUAL_USER_SELECTED only), matching Play Store expectations and avoiding unnecessary permission flags.

Bump version to 1.0.14.